### PR TITLE
init-daemon support

### DIFF
--- a/daemonInterface.sh
+++ b/daemonInterface.sh
@@ -1,0 +1,71 @@
+!/#bin/bash
+echo "Running run.sh script."
+
+# check wether env. var of host URI is set.
+# if not, assign a flag value
+echo "Resolving the daemon's address."
+echo  "----------------------------------"
+INIT_DAEMON_BASE_URI="${INIT_DAEMON_BASE_URI:-"UNSET"}"
+
+if [   $INIT_DAEMON_BASE_URI = "UNSET" ] ; then
+	echo "INIT_DAEMON_BASE_URI is unset."
+else
+	echo "INIT_DAEMON_BASE_URI is set to [$INIT_DAEMON_BASE_URI] from environment var."
+fi
+
+echo "Checking daemon information file env var."
+# check wether the DAEMON_INFO_FILE var with daemon information is set
+# this overrides the environment variable.
+DAEMON_INFO_FILE="${DAEMON_INFO_FILE:-"UNSET"}"
+if [ $DAEMON_INFO_FILE = "UNSET" ] ; then
+	echo "The DAEMON_INFO_FILE variable is not set."
+fi
+
+# check wether the file was indeed supplied in the container and set it.
+echo "Checking supplied file at [$DAEMON_INFO_FILE]."
+if [ ! -f $DAEMON_INFO_FILE ] ; then
+	echo "File $DAEMON_INFO_FILE does not exist."
+else
+	# purge whitespace and set
+	INIT_DAEMON_BASE_URI=$( cat $DAEMON_INFO_FILE | tr -d " \n\t\r")
+	echo "INIT_DAEMON_BASE_URI set to [$INIT_DAEMON_BASE_URI] from supplied file."
+	# TODO check for correct IP+port structure
+	# or, later, for correct http addr structure
+fi
+	
+if [   $INIT_DAEMON_BASE_URI = "UNSET" ] ; then
+	(>&2 echo "Failed to initialize remote daemon's address!.")
+	(>&2 echo "You need to supply the daemon's address either by setting INIT_DAEMON_BASE_URI.")
+	(>&2 echo "Or by writing it in a file, mounted on the container and set the path to DAEMON_INFO_FILE.")
+	exit
+fi
+	
+echo  "----------------------------------"
+
+export INIT_DAEMON_BASE_URI
+#INIT_DAEMON_STEP="TEST_STEP"
+echo 
+echo "Running step $INIT_DAEMON_STEP."
+echo
+
+
+echo
+echo "Daemon - validation:"
+$DAEMON_DIR/wait-for-step.sh
+
+echo
+echo "Daemon - execution:"
+$DAEMON_DIR/execute-step.sh
+
+# put execution code of the docker file here
+echo
+# dummy run
+echo "Here the container should run its task. Sleeping for 2s"
+sleep 2
+echo
+
+echo "Daemon - finish:"
+$DAEMON_DIR/finish-step.sh
+
+echo "Done."
+

--- a/execute-step.sh
+++ b/execute-step.sh
@@ -1,0 +1,25 @@
+
+#!/bin/bash
+
+# Added -d "" to curl to avoid the 411 Length Required error - this however
+# causes the server to respond with code 200
+
+
+if [ $ENABLE_INIT_DAEMON = "true" ]
+   then
+       echo "Execute step ${INIT_DAEMON_STEP} in pipeline"
+       while true; do
+           sleep $SLEEP_EXEC
+           msg="$INIT_DAEMON_BASE_URI/execute?step=$INIT_DAEMON_STEP"
+           printf "execute : sent [%s]\n" $msg
+           string=$(curl -sL -w "%{http_code}" -X PUT $msg -d "" -o /dev/null)
+           printf "execute : Got back string : [%s]\n"  $string
+
+           [ "$string" = "204" ] && break;
+
+           printf "sleeping\n"
+       done
+       echo "Notified execution of step ${INIT_DAEMON_STEP}"
+fi
+
+

--- a/finish-step.sh
+++ b/finish-step.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ $ENABLE_INIT_DAEMON = "true" ]
+   then
+       echo "Finish step ${INIT_DAEMON_STEP} in pipeline"
+       while true; do
+           sleep $SLEEP_FINISH
+           msg="$INIT_DAEMON_BASE_URI/finish?step=$INIT_DAEMON_STEP"
+           printf "finish : sent [%s]\n" $msg
+           string=$(curl -sL -w "%{http_code}" -X PUT $msg -d "" -o /dev/null)
+           printf "finish : Got back string : [%s]\n" $string
+
+           [ "$string" = "204" ] && break
+           printf "sleeping\n"
+       done
+       echo "Notified finish of step ${INIT_DAEMON_STEP}"
+fi
+
+
+
+
+
+
+
+

--- a/wait-for-step.sh
+++ b/wait-for-step.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $ENABLE_INIT_DAEMON = "true" ]
+   then
+       echo "Validating if step ${INIT_DAEMON_STEP} can start in pipeline"
+       while true; do
+           sleep $SLEEP_WAIT
+           msg="$INIT_DAEMON_BASE_URI/canStart?step=$INIT_DAEMON_STEP"
+           printf "wait : sent [%s]\n" $msg
+           string=$(curl -s $msg)
+           printf "wait : Got back string : [%s]\n" $string
+
+           [ "$string" = "true" ] && break
+           printf "sleeping\n"
+       done
+       echo "Can start step ${INIT_DAEMON_STEP} in pipeline"
+fi


### PR DESCRIPTION
Provided init-daemon probing scripts and interface.
Added copy instructions and env variables declarations in Dockerfile.
Added ARG daemon_directory Dockerfile argument to specify the daemon files' directory.
Added default init-daemon address override file lookup.
Added curl installation.
